### PR TITLE
FIX: update selector to hide standard btn

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,5 @@
 .navigation-controls {
-  .notifications-button.category-notifications-button {
+  .notifications-tracking-trigger-btn {
     display: none;
   }
 }


### PR DESCRIPTION
Updates the selector for the css that hides the standard button, as it recently [changed](https://github.com/discourse/discourse/pull/30298). This caused an issue where the was a duplication of category follow/tracking buttons when this component was enabled.

![image](https://github.com/user-attachments/assets/62738317-aa5f-4424-b477-f7e8f5cbb2df)