### PR TITLE
UX: show tracking button for tags page

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,4 @@
-.navigation-controls {
+body:not(.tags-page) .navigation-controls {
   .notifications-tracking-trigger-btn {
     display: none;
   }


### PR DESCRIPTION
The theme component doesn't show the follow button on the tags page, so we need to adjust the `display: none` logic to prevent the standard button from being hidden there.