### PR TITLE
DEV: fix discourse.select-kit-resolved-components

### DIFF
--- a/javascripts/discourse/components/category-notifications-dropdown.js
+++ b/javascripts/discourse/components/category-notifications-dropdown.js
@@ -3,12 +3,11 @@ import { classNames } from "@ember-decorators/component";
 import { allLevels, buttonDetails } from "discourse/lib/notification-levels";
 import { i18n } from "discourse-i18n";
 import DropdownSelectBoxComponent from "select-kit/components/dropdown-select-box";
+import NotificationsButtonRow from "select-kit/components/notifications-button/notifications-button-row";
 import {
   pluginApiIdentifiers,
   selectKitOptions,
 } from "select-kit/components/select-kit";
-import NotificationsButtonRow from "select-kit/components/notifications-button/notifications-button-row";
-
 
 @selectKitOptions({
   autoFilterable: false,

--- a/javascripts/discourse/components/category-notifications-dropdown.js
+++ b/javascripts/discourse/components/category-notifications-dropdown.js
@@ -7,6 +7,8 @@ import {
   pluginApiIdentifiers,
   selectKitOptions,
 } from "select-kit/components/select-kit";
+import NotificationsButtonRow from "select-kit/components/notifications-button/notifications-button-row";
+
 
 @selectKitOptions({
   autoFilterable: false,
@@ -21,7 +23,7 @@ export default class FollowNotificationsDropdown extends DropdownSelectBoxCompon
   nameProperty = "key";
 
   modifyComponentForRow() {
-    return "notifications-button/notifications-button-row";
+    return NotificationsButtonRow;
   }
 
   modifySelection(content) {


### PR DESCRIPTION
We have to import components class and not reference them by string.