### PR TITLE
FIX: Resolve i18n call at render time instead of module load

### DIFF
--- a/javascripts/discourse/components/category-notifications-dropdown-button.js
+++ b/javascripts/discourse/components/category-notifications-dropdown-button.js
@@ -11,9 +11,13 @@ import CategoryNotificationsDropdown from "./category-notifications-dropdown";
 @selectKitOptions({
   showFullTitle: true,
   i18nPrefix: themePrefix("category_options.notifications"),
-  headerAriaLabel: i18n(themePrefix("category_options.notifications.title")),
+  headerAriaLabel: "translatedHeaderAriaLabel",
 })
 @classNames("category-notifications-dropdown-button")
 export default class CategoryNotificationsDropdownButton extends CategoryNotificationsDropdown {
   @readOnly("category.deleted") isHidden;
+
+  get translatedHeaderAriaLabel() {
+    return i18n(themePrefix("category_options.notifications.title"));
+  }
 }


### PR DESCRIPTION
The headerAriaLabel option was initialized via i18n() in the @selectKitOptions decorator, which is evaluated at class definition time (module load). This means the translation is baked into the JS bundle and Site Text overrides never take effect.

Use a property name reference in the decorator instead, pointing to a getter that resolves the translation at runtime. SelectKit already supports this — when an option value is a string matching a property name on the component, it resolves to that property's computed value.

Core fix - https://github.com/discourse/discourse/pull/37041